### PR TITLE
Add ARMhf support

### DIFF
--- a/Dockerfile_ARM
+++ b/Dockerfile_ARM
@@ -1,0 +1,18 @@
+FROM forumi0721/alpine-armhf-base
+MAINTAINER Robbert Klarenbeek <robbertkl@renbeek.nl>
+
+#For cross compile on dockerhub
+RUN ["docker-build-start"]
+
+RUN apk add --no-cache \
+        ip6tables
+
+ENV DOCKER_IPV6NAT_VERSION v0.2.0
+ADD https://github.com/robbertkl/docker-ipv6nat/releases/download/${DOCKER_IPV6NAT_VERSION}/docker-ipv6nat-armhf /docker-ipv6nat
+RUN chmod u+x /docker-ipv6nat
+
+#For cross compile on dockerhub
+RUN ["docker-build-end"]
+
+ENTRYPOINT ["/docker-ipv6nat"]
+CMD ["--retry"]


### PR DESCRIPTION
Related to #7 

The Dockerfile assumes that the armhf binary could be downloaded from this URL:
```
https://github.com/robbertkl/docker-ipv6nat/releases/download/${DOCKER_IPV6NAT_VERSION}/docker-ipv6nat-armhf
```
Please fix according to your naming schema once you'll push the release :)