### PR TITLE
Fix an infinite loop in error handling

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -15,8 +15,8 @@ type RecoverableError struct {
 	err error
 }
 
-func (err *RecoverableError) Error() string {
-	return err.Error()
+func (re *RecoverableError) Error() string {
+	return re.err.Error()
 }
 
 // Number of seconds to wait after connection failure.


### PR DESCRIPTION
This fixes an apparent error in handling RecoverableError type which causes an infinite loop and goroutine stack overflow, e.g. when the connection to docker is lost.