### PR TITLE
Log ruleset changes to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ net.ipv6.conf.default.forwarding = 1
 
 The special value of 2 will allow accepting router advertisements even if forwarding is enabled.
 
+Setting the `-debug` flag for docker-ipv6nat will log all ruleset changes to stdout so you can check your logs how docker-ipv6nat is modifing your ip6tables rulesets.
+
 ## Authors
 
 * Robbert Klarenbeek, <robbertkl@renbeek.nl>

--- a/cmd/docker-ipv6nat/main.go
+++ b/cmd/docker-ipv6nat/main.go
@@ -76,7 +76,7 @@ func run() error {
 		return err
 	}
 
-	state, err := dockeripv6nat.NewState()
+	state, err := dockeripv6nat.NewState(debug)
 	if err != nil {
 		return err
 	}

--- a/cmd/docker-ipv6nat/main.go
+++ b/cmd/docker-ipv6nat/main.go
@@ -17,6 +17,7 @@ var (
 	retry         bool
 	userlandProxy bool
 	version       bool
+	debug         bool
 )
 
 func usage() {
@@ -41,6 +42,7 @@ func initFlags() {
 	flag.BoolVar(&cleanup, "cleanup", false, "remove rules when shutting down")
 	flag.BoolVar(&retry, "retry", false, "keep retrying to reconnect after a disconnect")
 	flag.BoolVar(&version, "version", false, "show version")
+	flag.BoolVar(&debug, "debug", false, "log ruleset changes to stdout")
 
 	flag.Usage = usage
 	flag.Parse()
@@ -65,6 +67,10 @@ func main() {
 }
 
 func run() error {
+	if debug {
+		log.Println("docker-ipv6nat is running in debug mode")
+	}
+
 	client, err := docker.NewClientFromEnv()
 	if err != nil {
 		return err

--- a/firewall.go
+++ b/firewall.go
@@ -104,15 +104,20 @@ func (s1 *Ruleset) Diff(s2 *Ruleset) *Ruleset {
 type firewall struct {
 	ipt         *iptables.IPTables
 	activeRules map[TableChain]map[string]bool
+	debug       bool
 }
 
-func NewFirewall() (*firewall, error) {
+func NewFirewall(debug bool) (*firewall, error) {
 	ipt, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
 	if err != nil {
 		return nil, err
 	}
 
-	return &firewall{ipt: ipt, activeRules: make(map[TableChain]map[string]bool)}, nil
+	return &firewall{
+		ipt:         ipt,
+		activeRules: make(map[TableChain]map[string]bool),
+		debug:       debug,
+	}, nil
 }
 
 func (fw *firewall) activateRule(r *rule) {

--- a/firewall.go
+++ b/firewall.go
@@ -1,6 +1,7 @@
 package dockeripv6nat
 
 import (
+	"log"
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -168,6 +169,9 @@ func (fw *firewall) EnsureRules(rules *Ruleset) error {
 			if err := fw.ipt.Insert(string(rule.tc.table), string(rule.tc.chain), len(fw.activeRules[rule.tc])+1, rule.spec...); err != nil {
 				return err
 			}
+			if fw.debug {
+				log.Println("rule added: -t", string(rule.tc.table), "-A", string(rule.tc.chain), len(fw.activeRules[rule.tc])+1, strings.Join(rule.spec, " "))
+			}
 		}
 		fw.activateRule(rule)
 	}
@@ -188,6 +192,9 @@ func (fw *firewall) EnsureRules(rules *Ruleset) error {
 			if err := fw.ipt.Insert(string(rule.tc.table), string(rule.tc.chain), 1, rule.spec...); err != nil {
 				return err
 			}
+			if fw.debug {
+				log.Println("rule added: -t", string(rule.tc.table), "-A", string(rule.tc.chain), 1, strings.Join(rule.spec, " "))
+			}
 		}
 		fw.activateRule(rule)
 	}
@@ -206,6 +213,9 @@ func (fw *firewall) RemoveRules(rules *Ruleset) error {
 		if exists {
 			if err := fw.ipt.Delete(string(rule.tc.table), string(rule.tc.chain), rule.spec...); err != nil {
 				return err
+			}
+			if fw.debug {
+				log.Println("rule removed: -t", string(rule.tc.table), "-D", string(rule.tc.chain), strings.Join(rule.spec, " "))
 			}
 		}
 		fw.deactivateRule(rule)

--- a/manager.go
+++ b/manager.go
@@ -37,13 +37,13 @@ type manager struct {
 	hairpinMode bool
 }
 
-func NewManager() (*manager, error) {
+func NewManager(debug bool) (*manager, error) {
 	hairpinMode, err := detectHairpinMode()
 	if err != nil {
 		return nil, err
 	}
 
-	fw, err := NewFirewall()
+	fw, err := NewFirewall(debug)
 	if err != nil {
 		return nil, err
 	}

--- a/state.go
+++ b/state.go
@@ -20,8 +20,8 @@ var ulaCIDR = net.IPNet{
 	Mask: net.CIDRMask(7, 128),
 }
 
-func NewState() (*state, error) {
-	manager, err := NewManager()
+func NewState(debug bool) (*state, error) {
+	manager, err := NewManager(debug)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### New Feature

If one calls `docker-ipv6nat` with the `-debug` flag, every added or removed rule will be logged to stdout.

---
Fixes #31 