### PR TITLE
Use two isolation stages for docker networks

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -22,7 +22,8 @@ const (
 	ChainPostrouting     = "POSTROUTING"
 	ChainForward         = "FORWARD"
 	ChainDocker          = "DOCKER"
-	ChainDockerIsolation = "DOCKER-ISOLATION"
+	ChainDockerIsolation1 = "DOCKER-ISOLATION-STAGE-1"
+	ChainDockerIsolation2 = "DOCKER-ISOLATION-STAGE-2"
 )
 
 type TableChain struct {

--- a/firewall.go
+++ b/firewall.go
@@ -16,12 +16,12 @@ const (
 type Chain string
 
 const (
-	ChainInput           = "INPUT"
-	ChainOutput          = "OUTPUT"
-	ChainPrerouting      = "PREROUTING"
-	ChainPostrouting     = "POSTROUTING"
-	ChainForward         = "FORWARD"
-	ChainDocker          = "DOCKER"
+	ChainInput            = "INPUT"
+	ChainOutput           = "OUTPUT"
+	ChainPrerouting       = "PREROUTING"
+	ChainPostrouting      = "POSTROUTING"
+	ChainForward          = "FORWARD"
+	ChainDocker           = "DOCKER"
 	ChainDockerIsolation1 = "DOCKER-ISOLATION-STAGE-1"
 	ChainDockerIsolation2 = "DOCKER-ISOLATION-STAGE-2"
 )

--- a/manager.go
+++ b/manager.go
@@ -177,13 +177,15 @@ func getRulesForNetwork(network *managedNetwork, hairpinMode bool) *Ruleset {
 	if network.internal {
 		return &Ruleset{
 			// internal: drop traffic to docker network from foreign subnet
+			// notice: rule is different from IPv4 counterpart because NDP should not be blocked
 			NewPrependRule(TableFilter, ChainDockerIsolation1,
-				"!", "-s", network.subnet.String(),
+				"!", "-i", network.bridge,
 				"-o", network.bridge,
 				"-j", "DROP"),
 			// internal: drop traffic from docker network to foreign subnet
+			// notice: rule is different from IPv4 counterpart because NDP should not be blocked
 			NewPrependRule(TableFilter, ChainDockerIsolation1,
-				"!", "-d", network.subnet.String(),
+				"!", "-o", network.bridge,
 				"-i", network.bridge,
 				"-j", "DROP"),
 			// ICC

--- a/state.go
+++ b/state.go
@@ -80,17 +80,7 @@ func (s *state) UpdateNetwork(id string, network *docker.Network) error {
 
 	if newNetwork == nil {
 		delete(s.networks, id)
-		if oldNetwork != nil {
-			if err := s.manager.RemoveInterconnectionRules(oldNetwork, s.getKnownNetworks()); err != nil {
-				return err
-			}
-		}
 	} else {
-		if oldNetwork == nil {
-			if err := s.manager.EnsureInterconnectionRules(newNetwork, s.getKnownNetworks()); err != nil {
-				return err
-			}
-		}
 		s.networks[id] = newNetwork
 	}
 


### PR DESCRIPTION
This MR implements an IPv6 version of [docker/libnetwork#2117](https://github.com/docker/libnetwork/pull/2117/files).

Fixes #22 
Closes #22

/cc @robbertkl 