### PR TITLE
Create DOCKER-USER chain and implement its behavior

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -48,6 +48,10 @@ func NewManager() (*manager, error) {
 		return nil, err
 	}
 
+	if err := fw.EnsureUserFilterChain(); err != nil {
+		return nil, err
+	}
+
 	if err := fw.EnsureTableChains(getCustomTableChains()); err != nil {
 		return nil, err
 	}
@@ -157,6 +161,8 @@ func getBaseRules(hairpinMode bool) *Ruleset {
 	}
 
 	return &Ruleset{
+		NewPrependRule(TableFilter, ChainForward,
+			"-j", ChainDockerUser),
 		NewPrependRule(TableFilter, ChainForward,
 			"-j", ChainDockerIsolation),
 		NewRule(TableFilter, ChainDockerIsolation,


### PR DESCRIPTION
The chain itself and its rules will not be removed when exiting
docker-ipv6nat. Existing rules will also not be modified or removed when
docker-ipv6nat is started.

The jump to DOCKER-USER from FORWARD will be the first rule in FORWARD
and will not be removed when exiting.

Fixes #25 
Closes #25 

/cc @robbertkl 