### PR TITLE
Fix issue caused by different iptables versions

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -99,6 +99,16 @@ func detectHairpinMode() (bool, error) {
 		return false, nil
 	}
 
+	// Old iptables misinterprets prefix matches in new iptables
+	hairpinModeOffRulespec[2] = "127.0.0.0/32"
+
+	hairpinModeOff, err = ipt.Exists(TableNat, ChainOutput, hairpinModeOffRulespec...)
+	if err != nil {
+		return false, err
+	} else if hairpinModeOff {
+		return false, nil
+	}
+
 	return false, errors.New("unable to detect hairpin mode (is the docker daemon running?)")
 }
 


### PR DESCRIPTION
A backport of "nft: Optimize class-based IP prefix matches" from
newer iptables versions broke the hairpin mode detection of ipv6nat.
This is caused by newer versions on the host create optimized ipt
rules, which will be interpreted different by older versions of
iptables. This can be spotted when you dump the rules on the host
and compare it to the rules dumped inside the ipv6nat container.
The outside rule contains the correct subnet for the detection,
127.0.0.0/8 while inside it is displayed as 127.0.0.0/32 which
causes the detection (code in manager.go) to fail. As this is only
a display issue (the rule is correct), accepting both versions
should be fine to get around this issue.

Big thanks to Phil Sutter who provided me the code to implement
my idea to cover old and new versions to be matched, as it is
very hard to ensure the same iptables version to be used inside
and outside the container. A test build is available on docker
hub at geektoor/ipv6nat-devel.

Closes: #67
Cc: Phil Sutter <phil@nwl.cc>
Signed-off-by: Sven Michels <michels@redhat.com>